### PR TITLE
Make OSX on Forge 1.8.9 work

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -164,4 +164,8 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	default ForgeProvider getForgeProvider() {
 		return getDependencyManager().getProvider(ForgeProvider.class);
 	}
+
+	default boolean hasLWJGL2() {
+		return getMinecraftProvider().getLibraryProvider().hasLWJGL2();
+	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -180,11 +180,11 @@ public final class CompileConfiguration {
 		Javadoc javadoc = (Javadoc) p.getTasks().getByName(JavaPlugin.JAVADOC_TASK_NAME);
 		javadoc.setClasspath(main.getOutput().plus(main.getCompileClasspath()));
 
-		p.afterEvaluate(project -> {
-			LoomGradleExtension extension = LoomGradleExtension.get(project);
+		LoomGradleExtension extension = LoomGradleExtension.get(p);
 
-			LoomDependencyManager dependencyManager = new LoomDependencyManager();
-			extension.setDependencyManager(dependencyManager);
+		LoomDependencyManager dependencyManager = new LoomDependencyManager();
+		extension.setDependencyManager(dependencyManager);
+		p.afterEvaluate(project -> {
 
 			dependencyManager.addProvider(new MinecraftProviderImpl(project));
 

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -261,7 +261,7 @@ public final class RunConfigSettings implements Named {
 	 * Add the {@code -XstartOnFirstThread} JVM argument when on OSX.
 	 */
 	public void startFirstThread() {
-		if (OperatingSystem.getOS().equalsIgnoreCase("osx")) {
+		if (OperatingSystem.getOS().equalsIgnoreCase("osx") && !extension.hasLWJGL2()) {
 			vmArg("-XstartOnFirstThread");
 		}
 	}
@@ -278,7 +278,6 @@ public final class RunConfigSettings implements Named {
 	 * Configure run config with the default client options.
 	 */
 	public void client() {
-		startFirstThread();
 		environment("client");
 		defaultMainClass(getExtension().isForge() ? Constants.Forge.LAUNCH_TESTING : Constants.Knot.KNOT_CLIENT);
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
@@ -35,16 +35,26 @@ import net.fabricmc.loom.util.Constants;
 public class MinecraftLibraryProvider {
 	public File MINECRAFT_LIBS;
 
+	private boolean hasLWJGL2 = false;
+
 	public void provide(MinecraftProviderImpl minecraftProvider, Project project) {
 		MinecraftVersionMeta versionInfo = minecraftProvider.getVersionInfo();
 
 		initFiles(project, minecraftProvider);
 
+
+		boolean lwjgl2 = false;
 		for (MinecraftVersionMeta.Library library : versionInfo.libraries()) {
 			if (library.isValidForOS() && !library.hasNatives() && library.artifact() != null) {
 				project.getDependencies().add(Constants.Configurations.MINECRAFT_DEPENDENCIES, library.name());
+				lwjgl2 |= library.name().startsWith("org.lwjgl.lwjgl:lwjgl:2.");
 			}
 		}
+		hasLWJGL2 = lwjgl2;
+	}
+
+	public boolean hasLWJGL2() {
+		return hasLWJGL2;
 	}
 
 	private void initFiles(Project project, MinecraftProviderImpl minecraftProvider) {

--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -130,6 +130,12 @@ public final class LoomTasks {
 		});
 
 		extension.getRunConfigs().create("client", RunConfigSettings::client);
+		project.afterEvaluate(p -> {
+			RunConfigSettings client = extension.getRunConfigs().findByName("client");
+			if (client != null) {
+				client.startFirstThread();
+			}
+		});
 		extension.getRunConfigs().create("server", RunConfigSettings::server);
 	}
 


### PR DESCRIPTION
removes the `-Xstartonfirstthread` argument with lwjgl2, which causes crashes on osx.