### PR TITLE
bump fabric-mixin-compile-extensions version

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -130,7 +130,7 @@ public class Constants {
 		 * Constants for versions of dependencies.
 		 */
 		public static final class Versions {
-			public static final String MIXIN_COMPILE_EXTENSIONS = "0.4.6";
+			public static final String MIXIN_COMPILE_EXTENSIONS = "0.5.0";
 			public static final String DEV_LAUNCH_INJECTOR = "0.2.1+build.8";
 			public static final String TERMINAL_CONSOLE_APPENDER = "1.2.0";
 			public static final String JETBRAINS_ANNOTATIONS = "22.0.0";


### PR DESCRIPTION
This ensures the mixin 0.8.5 AP is used. Please bump arch-loom version in EGT after merging and releasing this.