### PR TITLE
Add SHA1 suffix to intermediaries

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
@@ -25,8 +25,11 @@
 package net.fabricmc.loom.configuration.providers.mappings;
 
 import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 
 import com.google.common.net.UrlEscapers;
 import org.gradle.api.provider.Property;
@@ -68,6 +71,20 @@ public abstract class IntermediaryMappingsProvider extends IntermediateMappingsP
 
 	@Override
 	public @NotNull String getName() {
-		return "intermediary-v2";
+		final String encodedMcVersion = UrlEscapers.urlFragmentEscaper().escape(getMinecraftVersion().get());
+		final String url = getIntermediaryUrl().get().formatted(encodedMcVersion);
+		return "intermediary-v2-" + getSha1(url);
+	}
+
+	private String getSha1(String value) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-1");
+			digest.reset();
+			digest.update(value.getBytes(StandardCharsets.UTF_8));
+			return String.format("%040x", new BigInteger(1, digest.digest()));
+		} catch (Exception e){
+			e.printStackTrace();
+			return "";
+		}
 	}
 }


### PR DESCRIPTION
Different intermediary URLs break in a multi-platform setup (like preprocessor), so we use this to differentiate between intermediaries.