### PR TITLE
Fix macOS on LWJGL 2 and don't force maven central on LWJGL 2

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -181,4 +181,8 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 
 	ForgeRunsProvider getForgeRunsProvider();
 	void setForgeRunsProvider(ForgeRunsProvider forgeRunsProvider);
+
+	default boolean hasLWJGL2() {
+		return getMinecraftProvider().getLibraryProvider().getProcessorManager().hasLWJGL2();
+	}
 }

--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -36,6 +36,7 @@ import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.PluginAware;
 import org.jetbrains.annotations.NotNull;
 
+import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryContext;
 import net.fabricmc.loom.extension.LoomFiles;
 import net.fabricmc.loom.util.MirrorUtil;
 
@@ -146,8 +147,8 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 		});
 	}
 
-	public static void forceLWJGLFromMavenCentral(RepositoryHandler repositories) {
-		if (repositories.findByName("MavenCentralLWJGL") != null) {
+	public static void forceLWJGLFromMavenCentral(RepositoryHandler repositories, LibraryContext context) {
+		if (repositories.findByName("MavenCentralLWJGL") != null && !context.usesLWJGL3()) {
 			// Already applied.
 			return;
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -310,7 +310,7 @@ public final class RunConfigSettings implements Named {
 	 * Add the {@code -XstartOnFirstThread} JVM argument when on OSX.
 	 */
 	public void startFirstThread() {
-		if (Platform.CURRENT.getOperatingSystem().isMacOS()) {
+		if (Platform.CURRENT.getOperatingSystem().isMacOS() && !extension.hasLWJGL2()) {
 			vmArg("-XstartOnFirstThread");
 		}
 	}
@@ -327,7 +327,6 @@ public final class RunConfigSettings implements Named {
 	 * Configure run config with the default client options.
 	 */
 	public void client() {
-		startFirstThread();
 		environment("client");
 		defaultMainClass(Constants.Knot.KNOT_CLIENT);
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
@@ -160,4 +160,8 @@ public class MinecraftLibraryProvider {
 			md.setTransitive(false);
 		}
 	}
+
+	public LibraryProcessorManager getProcessorManager() {
+		return processorManager;
+	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
@@ -264,6 +264,10 @@ public abstract class MinecraftProvider {
 		return versionInfo;
 	}
 
+	public MinecraftLibraryProvider getLibraryProvider() {
+		return libraryProvider;
+	}
+
 	public String getJarPrefix() {
 		return jarPrefix;
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryProcessorManager.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryProcessorManager.java
@@ -56,6 +56,7 @@ public class LibraryProcessorManager {
 	private final Platform platform;
 	private final RepositoryHandler repositories;
 	private final List<String> enabledProcessors;
+	private boolean hasLWJGL2;
 
 	public LibraryProcessorManager(Platform platform, RepositoryHandler repositories, List<String> enabledProcessors) {
 		this.platform = platform;
@@ -119,9 +120,19 @@ public class LibraryProcessorManager {
 			libraries = processedLibraries;
 		}
 
+		boolean lwjgl2 = false;
+		for (Library library : libraries) {
+			lwjgl2 |= library.name().startsWith("org.lwjgl.lwjgl:lwjgl:2.");
+		}
+		hasLWJGL2 = lwjgl2;
+
 		return Collections.unmodifiableList(libraries);
 	}
 
 	public interface LibraryProcessorFactory<T extends LibraryProcessor> extends BiFunction<Platform, LibraryContext, T> {
+	}
+
+	public boolean hasLWJGL2() {
+		return hasLWJGL2;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryProcessorManager.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryProcessorManager.java
@@ -122,7 +122,10 @@ public class LibraryProcessorManager {
 
 		boolean lwjgl2 = false;
 		for (Library library : libraries) {
-			lwjgl2 |= library.name().startsWith("org.lwjgl.lwjgl:lwjgl:2.");
+			lwjgl2 = library.name().startsWith("org.lwjgl.lwjgl:lwjgl:2.");
+			if (lwjgl2) {
+				break;
+			}
 		}
 		hasLWJGL2 = lwjgl2;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/ArmNativesLibraryProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/ArmNativesLibraryProcessor.java
@@ -101,6 +101,6 @@ public class ArmNativesLibraryProcessor extends LibraryProcessor {
 
 	@Override
 	public void applyRepositories(RepositoryHandler repositories) {
-		LoomRepositoryPlugin.forceLWJGLFromMavenCentral(repositories);
+		LoomRepositoryPlugin.forceLWJGLFromMavenCentral(repositories, context);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/LWJGL3UpgradeLibraryProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/LWJGL3UpgradeLibraryProcessor.java
@@ -80,7 +80,7 @@ public class LWJGL3UpgradeLibraryProcessor extends LibraryProcessor {
 
 	@Override
 	public void applyRepositories(RepositoryHandler repositories) {
-		LoomRepositoryPlugin.forceLWJGLFromMavenCentral(repositories);
+		LoomRepositoryPlugin.forceLWJGLFromMavenCentral(repositories, context);
 	}
 
 	// Add support for macOS

--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -150,6 +150,12 @@ public abstract class LoomTasks implements Runnable {
 			});
 		});
 		extension.getRunConfigs().create("client", RunConfigSettings::client);
+		getProject().afterEvaluate(p -> {
+			RunConfigSettings client = extension.getRunConfigs().findByName("client");
+			if (client != null) {
+				client.startFirstThread();
+			}
+		});
 		extension.getRunConfigs().create("server", RunConfigSettings::server);
 
 		// Remove the client or server run config when not required. Done by name to not remove any possible custom run configs


### PR DESCRIPTION
`-XstartOnFirstThread` is only needed on LWJGL 3, and causes crashes on LWJGL 2.

Adapted from https://github.com/EssentialGG/architectury-loom/pull/2 to work with Loom 1.2