### PR TITLE
Add 1.13.2 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ dependencies {
 	implementation libs.night.config.toml
 
 	// Legacy Forge patches
-	implementation libs.lzma
+	implementation libs.xz
 
 	// Testing
 	testImplementation(gradleTestKit())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ forge-diffpatch = "2.0.7"
 night-config = "3.6.6"
 datafixerupper = "6.0.8"
 at = "1.0.1"
-lzma = "1.3"
+xz = "1.8"
 
 [libraries]
 # Loom compile libraries
@@ -65,7 +65,7 @@ forge-diffpatch = { module = "net.minecraftforge:DiffPatch", version.ref = "forg
 night-config-toml = { module = "com.electronwill.night-config:toml", version.ref = "night-config" }
 datafixerupper = { module = "com.mojang:datafixerupper", version.ref = "datafixerupper" }
 at = { module = "dev.architectury:at", version.ref = "at" }
-lzma = { module = "com.github.jponge:lzma-java", version.ref = "lzma" }
+xz = { module = "org.tukaani:xz", version.ref = "xz" }
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -176,8 +176,12 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 		return isForgeLike() && !getMcpConfigProvider().isOfficial();
 	}
 
+	default int getForgeSpec() {
+		return getForgeUserdevProvider().getForgeSpec();
+	}
+
 	default boolean isLegacyForge() {
-		return isForge() && getForgeUserdevProvider().isLegacyForge();
+		return isForge() && getForgeSpec() <= 1;
 	}
 
 	default boolean isModernForge() {

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -226,13 +226,13 @@ public abstract class CompileConfiguration implements Runnable {
 		// but before MinecraftPatchedProvider.provide.
 		setupDependencyProviders(project, extension);
 
-		if (extension.isLegacyForge()) {
+		if (extension.getForgeSpec() <= 2) {
 			extension.setIntermediateMappingsProvider(GeneratedIntermediateMappingsProvider.class, provider -> {
 				provider.minecraftProvider = minecraftProvider;
 			});
 		}
 
-		if (extension.isForgeLike() && !extension.isLegacyForge()) {
+		if (extension.isForgeLike() && extension.getForgeSpec() > 2) {
 			// Excluded on legacy forge because it pulls in a log4j-api version newer than what forge wants and we don't
 			// need it anyway
 			project.getDependencies().add(Constants.Configurations.FORGE_EXTRA, LoomVersions.UNPROTECT.mavenNotation());

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeMigratedMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeMigratedMappingConfiguration.java
@@ -53,7 +53,7 @@ public final class ForgeMigratedMappingConfiguration extends MappingConfiguratio
 	protected void manipulateMappings(Project project, Path mappingsJar) throws IOException {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 
-		if (extension.isLegacyForge()) {
+		if (extension.getForgeSpec() <= 2) {
 			// Legacy forge patches are in official namespace, so if the type of a field is changed by them, then that
 			// is effectively a new field and not traceable to any mapping. Therefore this does not apply to it.
 			return;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/PatchProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/PatchProvider.java
@@ -43,12 +43,11 @@ import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 
-import lzma.sdk.lzma.Decoder;
-import lzma.sdk.lzma.Encoder;
-import lzma.streams.LzmaInputStream;
-import lzma.streams.LzmaOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
+import org.tukaani.xz.LZMA2Options;
+import org.tukaani.xz.LZMAInputStream;
+import org.tukaani.xz.LZMAOutputStream;
 
 import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.providers.forge.fg2.Pack200Provider;
@@ -99,12 +98,12 @@ public class PatchProvider extends DependencyProvider {
 
 	private void splitAndConvertLegacyPatches(Path joinedLegacyPatches) throws IOException {
 		try (JarInputStream in = new JarInputStream(new ByteArrayInputStream(unpack200Lzma(joinedLegacyPatches)));
-				OutputStream clientFileOut = Files.newOutputStream(clientPatches, CREATE, TRUNCATE_EXISTING);
-				LzmaOutputStream clientLzmaOut = new LzmaOutputStream(clientFileOut, new Encoder());
-				JarOutputStream clientJarOut = new JarOutputStream(clientLzmaOut);
-				OutputStream serverFileOut = Files.newOutputStream(serverPatches, CREATE, TRUNCATE_EXISTING);
-				LzmaOutputStream serverLzmaOut = new LzmaOutputStream(serverFileOut, new Encoder());
-				JarOutputStream serverJarOut = new JarOutputStream(serverLzmaOut);
+			 OutputStream clientFileOut = Files.newOutputStream(clientPatches, CREATE, TRUNCATE_EXISTING);
+			 LZMAOutputStream clientLzmaOut = new LZMAOutputStream(clientFileOut, new LZMA2Options(), -1);
+			 JarOutputStream clientJarOut = new JarOutputStream(clientLzmaOut);
+			 OutputStream serverFileOut = Files.newOutputStream(serverPatches, CREATE, TRUNCATE_EXISTING);
+			 LZMAOutputStream serverLzmaOut = new LZMAOutputStream(serverFileOut, new LZMA2Options(), -1);
+			 JarOutputStream serverJarOut = new JarOutputStream(serverLzmaOut)
 		) {
 			for (JarEntry entry; (entry = in.getNextJarEntry()) != null;) {
 				String name = entry.getName();
@@ -153,7 +152,7 @@ public class PatchProvider extends DependencyProvider {
 	}
 
 	private byte[] unpack200Lzma(InputStream in) throws IOException {
-		try (LzmaInputStream lzmaIn = new LzmaInputStream(in, new Decoder())) {
+		try (LZMAInputStream lzmaIn = new LZMAInputStream(in)) {
 			return unpack200(lzmaIn);
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -227,7 +227,7 @@ public class MappingConfiguration {
 				// Merge tiny mappings with srg
 				Stopwatch stopwatch = Stopwatch.createStarted();
 				// FIXME why is this special case necessary?
-				ForgeMappingsMerger.ExtraMappings extraMappings = extension.isLegacyForge()
+				ForgeMappingsMerger.ExtraMappings extraMappings = extension.getForgeSpec() <= 2
 						? null
 						: ForgeMappingsMerger.ExtraMappings.ofMojmapTsrg(getMojmapSrgFileIfPossible(project));
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/forge/ForgeTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/forge/ForgeTest.groovy
@@ -65,6 +65,7 @@ class ForgeTest extends Specification implements GradleProjectTestTrait {
 		'1.16.5'  | '36.2.4'     | '8'         | '"de.oceanlabs.mcp:mcp_snapshot:20210309-1.16.5"'
 		'1.14.4'  | "28.2.23"    | '8'         | "loom.officialMojangMappings()"
 		'1.14.4'  | "28.2.23"    | '8'         | '"net.fabricmc:yarn:1.14.4+build.18:v2"'
+		'1.13.2'  | "25.0.223"   | '8'         | '"de.oceanlabs.mcp:mcp_stable:47-1.13.2"'
 		'1.12.2'  | "14.23.0.2486" | '8'       | '"de.oceanlabs.mcp:mcp_snapshot:20170615-1.12"'
 		'1.8.9'   | "11.15.1.2318-1.8.9" | '8' | '"de.oceanlabs.mcp:mcp_stable:22-1.8.9"'
 	}


### PR DESCRIPTION
First of all: Thank you very much for this fork of architectury-loom!
However, I have found a few issues related to 1.13.2 - it just did not want to work properly.
After some tinkering around with various configurations, I found the culprits:
 - The MCP repo patch needs to be applied to 1.13.2 configurations as well, however not the rest of the fixes related to FG2
 - Intermediary and mojmap are not available for 1.13.2 -> handle those like in 1.12.2
 - A few tiny things here and there

For this to work, the new implementation relies on the `spec` version (for some older Forge 1.13.2 versions we need to hack it to `2`, though).

Furthermore, during this whole process I found that the LZMA files that are being generated by legacy configurations are "damaged" - this is due to https://github.com/ning/jvm-compressor-benchmark/issues/1, which is referenced in https://github.com/jponge/lzma-java/issues/9.
Since `org.tukaani:xz:1.8` was already a (probably runtime (?)) dependency, I removed `lzma-java` and migrated the code to `xz`, which does not have any issues with silenced OOMs anymore.
